### PR TITLE
Prepare 7.0.0-ballot for publication

### DIFF
--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -1,6 +1,6 @@
 All significant changes to this FHIR implementation guide will be documented on this page.
 
-### STU 7, v7.0.0-ballot (unreleased)
+### STU 7, v7.0.0-ballot (2026-06-10)
 
 * [#398](https://github.com/hl7ch/ch-vacd/issues/398): Relax Organization cardinality from 1..* to 0..* in Immunization Administration and Vaccination Record Document
 * [#396](https://github.com/hl7ch/ch-vacd/issues/396): Typo in use case 14

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -7,6 +7,9 @@ Using as much as possible international code systems like SNOMED CT®, LOINC, ED
 
 <div markdown="1" class="stu-note">
 
+This implementation guide is under STU ballot by [HL7 Switzerland](https://www.hl7.ch/) from August 4th, 2026 until September 30th, 2026.
+Please add your feedback via the 'Propose a change'-link in the footer.
+
 [Changelog](changelog.html) with significant changes, open and closed issues.
 
 </div>

--- a/publication-request.json
+++ b/publication-request.json
@@ -1,11 +1,11 @@
 {
-  "package-id" : "ch.fhir.ig.ch-vacd",
-  "version" : "6.0.0",
-  "path" : "http://fhir.ch/ig/ch-vacd/6.0.0",
-  "mode" : "milestone",
-  "status" : "trial-use",
-  "sequence" : "STU 6",
-  "desc" : "HL7 Switzerland STU 6",
-  "changes" : "changelog.html",
+  "package-id": "ch.fhir.ig.ch-vacd",
+  "version": "7.0.0-ballot",
+  "path": "http://fhir.ch/ig/ch-vacd/7.0.0-ballot",
+  "mode": "milestone",
+  "status": "ballot",
+  "sequence": "STU 7",
+  "desc": "HL7 Switzerland STU 7 Ballot",
+  "changes": "changelog.html",
   "first": false
 }

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -50,7 +50,7 @@ dependencies:
   hl7.terminology.r4:
     uri: http://terminology.hl7.org/ImplementationGuide/hl7.terminology
     version: 7.0.1
-  ch.fhir.ig.ch-core: 7.0.x
+  ch.fhir.ig.ch-core: current
   ch.fhir.ig.ch-term: 3.4.x
 
 resources:

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -50,7 +50,7 @@ dependencies:
   hl7.terminology.r4:
     uri: http://terminology.hl7.org/ImplementationGuide/hl7.terminology
     version: 7.0.1
-  ch.fhir.ig.ch-core: current
+  ch.fhir.ig.ch-core: 7.0.0
   ch.fhir.ig.ch-term: 3.4.x
 
 resources:

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -9,11 +9,11 @@ title: Implementation Guide CH VACD
 # FSHOnly: true
 # applyExtensionMetadataToRoot: false
 status: active
-version: 7.0.0-ballot-ci-build
-date: 2025-12-16
+version: 7.0.0-ballot
+date: 2026-06-10
 fhirVersion: 4.0.1
 copyrightYear: 2021+
-releaseLabel: ci-build # ci-build | draft | qa-preview | ballot | trial-use | release | update | normative+trial-use
+releaseLabel: ballot # ci-build | draft | qa-preview | ballot | trial-use | release | update | normative+trial-use
 publisher:
   name: HL7 Switzerland
   url: https://www.hl7.ch/
@@ -50,8 +50,8 @@ dependencies:
   hl7.terminology.r4:
     uri: http://terminology.hl7.org/ImplementationGuide/hl7.terminology
     version: 7.0.1
-  ch.fhir.ig.ch-core: 6.0.0
-  ch.fhir.ig.ch-term: 3.3.x
+  ch.fhir.ig.ch-core: 7.0.x
+  ch.fhir.ig.ch-term: 3.4.x
 
 resources:
   CapabilityStatement/ch-vacd-api-capstmt-srv:

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -49,7 +49,7 @@ parameters:
 dependencies:
   hl7.terminology.r4:
     uri: http://terminology.hl7.org/ImplementationGuide/hl7.terminology
-    version: 7.0.1
+    version: 7.1.0
   ch.fhir.ig.ch-core: 7.0.0-ballot
   ch.fhir.ig.ch-term: 3.4.x
 

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -50,7 +50,7 @@ dependencies:
   hl7.terminology.r4:
     uri: http://terminology.hl7.org/ImplementationGuide/hl7.terminology
     version: 7.0.1
-  ch.fhir.ig.ch-core: 7.0.0
+  ch.fhir.ig.ch-core: 7.0.0-ballot
   ch.fhir.ig.ch-term: 3.4.x
 
 resources:


### PR DESCRIPTION
Prepare CH VACD 7.0.0-ballot for publication.

Changes:
- sushi-config.yaml: version, date, releaselabel, dependencies (ch-core 7.0.x, ch-term 3.4.x)
- publication-request.json: updated for 7.0.0-ballot
- index.md: added ballot notice
- changelog.md: set release date